### PR TITLE
Abréviation pour Monsieur

### DIFF
--- a/components/dirigeants-section/entreprise-individuelle.tsx
+++ b/components/dirigeants-section/entreprise-individuelle.tsx
@@ -21,7 +21,7 @@ const DirigeantsEntrepriseIndividuelleSection: React.FC<IProps> = ({
   const data = [
     //eslint-disable-next-line
     ['Rôle', <b>Représentant Légal</b>],
-    ['Nom', (dirigeant.sexe === 'M' ? 'Mr ' : 'Mme ') + dirigeant.nom],
+    ['Nom', (dirigeant.sexe === 'M' ? 'M. ' : 'Mme ') + dirigeant.nom],
     ['Prénom', dirigeant.prenom],
   ];
 


### PR DESCRIPTION
L'abréviation pour "Monsieur" est `M.` et non `Mr`

https://fr.wikipedia.org/wiki/Monsieur

> Monsieur est abrégé en « M. ». Anciennement on trouvait Mr .